### PR TITLE
Fix issue with timezone

### DIFF
--- a/PRE_PROCESSOR.groovy
+++ b/PRE_PROCESSOR.groovy
@@ -25,10 +25,10 @@ sampler.getArguments().each {arg ->
 }
 
 //Create the variable x-amz-date 
+TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 def now = new Date()
 def amzFormat = new SimpleDateFormat( "yyyyMMdd'T'HHmmss'Z'" )
 def stampFormat = new SimpleDateFormat( "yyyyMMdd" )
-amzFormat.setTimeZone(TimeZone.getTimeZone("UTC"));  //server timezone
 def amzDate = amzFormat.format(now)
 def dateStamp = stampFormat.format(now)
 vars.put("x_amz_date", amzDate)
@@ -126,4 +126,3 @@ public static String urlEncodeUTF8(Map<?,?> map) {
     }
     return sb.toString();       
 }
- 


### PR DESCRIPTION
Calculate the proper time if you machine is not set to UTC.  Example is if your timezone was CST and time was 6pm UTC would be the next day but time was being set to the midnight of the current day.  Setting your timezone default to UTC calculates it for you.
Local Time: 20190225 18:00:00
UTC Calculation: 20190225 00:00:00
VS
Should be: 20190226 00:00:00